### PR TITLE
Potential fix for code scanning alert no. 1: Query built by concatenation with a possibly-untrusted string

### DIFF
--- a/app/src/main/java/workshop05code/SQLiteConnectionManager.java
+++ b/app/src/main/java/workshop05code/SQLiteConnectionManager.java
@@ -127,10 +127,12 @@ public class SQLiteConnectionManager {
      */
     public void addValidWord(int id, String word) {
 
-        String sql = "INSERT INTO validWords(id,word) VALUES('" + id + "','" + word + "')";
+        String sql = "INSERT INTO validWords(id,word) VALUES(?, ?)";
 
         try (Connection conn = DriverManager.getConnection(databaseURL);
                 PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, id);
+            pstmt.setString(2, word);
             pstmt.executeUpdate();
         } catch (SQLException e) {
             System.out.println(e.getMessage());


### PR DESCRIPTION
Potential fix for [https://github.com/MQ-COMP3310/w05sqlinjectionpub-vxskxr/security/code-scanning/1](https://github.com/MQ-COMP3310/w05sqlinjectionpub-vxskxr/security/code-scanning/1)

To fix the problem, we need to replace the concatenated SQL query with a parameterized query using a prepared statement. This approach ensures that the input values are properly escaped and treated as data rather than executable code, thus preventing SQL injection attacks.

- Replace the concatenated SQL query with a parameterized query.
- Use placeholders (`?`) for the parameters in the SQL query.
- Set the values for the placeholders using the appropriate `set` methods on the `PreparedStatement` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
